### PR TITLE
feat: support enum, use Enum as attribute type not Object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/apidoc-plugin-ts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A plugin for apidoc leveraging TypeScript interfaces.",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,13 +202,17 @@ function setInterfaceElements (
     const propType = prop.getType().getText()
 
     // Determine if the type is an object
-    const propTypeIsObject = !isNativeType(propType)
+    let propTypeIsObject = !isNativeType(propType)
 
     // If type is an object change label
     const isArray = propTypeIsObject && propType.includes('[]')
+    const isEnum = prop.getType().isEnum()
+    if (isEnum) {
+      propTypeIsObject = false
+    }
     const propLabel = propTypeIsObject
       ? `Object${isArray ? '[]' : ''}`
-      : getCapitalized(propType)
+      : (isEnum ? 'Enum' : getCapitalized(propType))
 
     // Set the element
     newElements.push(getApiSuccessElement(`{${propLabel}} ${typeDef} ${description}`))
@@ -281,6 +285,12 @@ function setObjectElements<NodeType extends ts.Node = ts.Node> (
     // Nothing to do if prop is of native type
     if (isNativeType(propType)) {
       newElements.push(getApiSuccessElement(`{${getCapitalized(propType)}} ${typeDefLabel} ${desc}`))
+      return
+    }
+
+    const isEnum = valueDeclaration.getType().isEnum()
+    if (isEnum) {
+      newElements.push(getApiSuccessElement(`{Enum} ${typeDefLabel} ${desc}`))
       return
     }
 

--- a/test/enum-as-properties/fixture.json
+++ b/test/enum-as-properties/fixture.json
@@ -1,0 +1,88 @@
+[
+  {
+    "type": "get",
+    "url": "/api/:id",
+    "title": "",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "SquareEnumConfig",
+            "optional": false,
+            "field": "id",
+            "description": "<p>Unique ID.</p>"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "group": "Success 200",
+            "type": "Object[]",
+            "optional": false,
+            "field": "squares",
+            "description": "<p><code>squares</code></p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Enum",
+            "optional": false,
+            "field": "squares.color",
+            "description": "<p><code>squares.color</code></p>"
+          },
+          {
+            "group": "Success 200",
+            "type": "Number",
+            "optional": false,
+            "field": "squares.width",
+            "description": "<p><code>squares.width</code></p>"
+          }
+        ]
+      }
+    },
+    "group": "enumAsProperties",
+    "version": "0.0.0",
+    "filename": "enum-as-properties/index.ts",
+    "groupTitle": "enumAsProperties",
+    "name": "GetApiId"
+  },
+  {
+    "filename": "enum-as-properties/index.ts",
+    "group": "enumAsProperties",
+    "groupTitle": "enumAsProperties",
+    "name": "GetApiId",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "description": "<p>Unique ID.</p>",
+            "field": "id",
+            "group": "Parameter",
+            "optional": false,
+            "type": "SquareEnumConfig"
+          }
+        ]
+      }
+    },
+    "success": {
+      "fields": {
+        "Success 200": [
+          {
+            "description": "<p><code>color</code></p>",
+            "field": "color",
+            "group": "Success 200",
+            "optional": false,
+            "type": "Enum"
+          }
+        ]
+      }
+    },
+    "title": "",
+    "type": "get",
+    "url": "/api/:id",
+    "version": "0.0.0"
+  }
+]

--- a/test/enum-as-properties/index.ts
+++ b/test/enum-as-properties/index.ts
@@ -16,7 +16,6 @@ interface EnumInterface {
   color: Color
 }
 
-
 /**
  * @api {get} /api/:id
  * @apiParam {SquareEnumConfig} id Unique ID.

--- a/test/enum-as-properties/index.ts
+++ b/test/enum-as-properties/index.ts
@@ -1,0 +1,32 @@
+enum Color {
+  Red = 'red',
+  Blue = 'blue'
+}
+
+interface SquareEnumConfig {
+  color: Color
+  width: number
+}
+
+interface SquareEnumConfigsInterface {
+  squares: SquareEnumConfig[]
+}
+
+interface EnumInterface {
+  color: Color
+}
+
+
+/**
+ * @api {get} /api/:id
+ * @apiParam {SquareEnumConfig} id Unique ID.
+ * @apiInterface {SquareEnumConfigsInterface}
+ * @apiGroup enumAsProperties
+ */
+
+/**
+ * @api {get} /api/:id
+ * @apiParam {SquareEnumConfig} id Unique ID.
+ * @apiInterface {EnumInterface}
+ * @apiGroup enumAsProperties
+ */

--- a/test/test.ts
+++ b/test/test.ts
@@ -26,6 +26,10 @@ const tests = [
   {
     only: false,
     name: 'namespaces'
+  },
+  {
+    only: false,
+    name: 'enum-as-properties'
   }
 ]
 describe('Apidoc TS Plugin', () => {


### PR DESCRIPTION
Enum is not supported. An `Enum` properties will be set to `Object` in apidoc.

I change the output in apidoc from `Object` to `Enum`
